### PR TITLE
Tweak styles

### DIFF
--- a/www/bingo-card.css
+++ b/www/bingo-card.css
@@ -12,8 +12,9 @@
   grid-template-rows: 1.5em;
   grid-gap: 2px;
   margin-top: 5px;
-  margin-bottom: 2px;
+  margin-bottom: 0;
   font-family: 'Nunito', sans-serif;
+  border: 2px solid white; /* mirror 'table' border approach used below */
 }
 
 .card h1 span {
@@ -28,17 +29,26 @@
   width: 100%;
   grid-template-columns: repeat(5, 1fr);
   grid-auto-rows: 1fr;
-  grid-gap: 1px;
+  grid-gap: 2px; /* cell border width */
   font-family: 'BenchNine', sans-serif;
+  background-color: silver; /* cell border color */
+  border: 2px solid silver; /* outside cell border (aka table border) */
+  /* 
+    To Do: Sassify these styles to use variables for the border width and color, allowing more consistent control
+  */
 }
 
 .board > div {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  border: 1px solid silver;
   text-align: center;
   min-height: 5.3em;
+  background-color: white; /* required to make border colors work */
+}
+
+.board > div > div {
+  padding: 15px; /* give text some breathing room */
 }
 
 .board .marked {

--- a/www/bingo-card.css
+++ b/www/bingo-card.css
@@ -9,7 +9,6 @@
   width: 100%;
   font-size: 20px;
   grid-template-columns: repeat(5, 1fr);
-  grid-template-rows: 1.5em;
   grid-gap: 2px;
   margin-top: 5px;
   margin-bottom: 0;


### PR DESCRIPTION
The CSS grid doesn't give you an easy approach to styling borders in a way that makes two shared borders collapse; therefore, you have to trick it by removing the borders from the actual div cell and using the grid-gap as the border width. This approach does not yield any borders on the outside of the div cells, so you need to specify a border for the container with the same width as the grid-gap. For the border color, you simply make the grid container have a background color of what you want the border color to be. Oddly, this was an old HTML table trick for the Netscape 4/IE 5 era. What was old is new again...or as Tolkien would put it: There and Back Again...A Table's Tale.

Also, a pet peeve of mine is text that gets too close to borders, so I give it just a little bit of padding as breathing room to help readability. Usually a 10px or 15px padding is sufficient. Because of typography appearances, mostly with line height, you can subtract a little from top and bottom padding to make the padding look consistent, something like 15px side padding and 10px top and bottom padding. I just kept it consistent here because the text is centered vertically in the cell as opposed to a header or top nav approach.

Take a look at the BINGO header and you'll notice that it consistently mirrors the border of the cells below, just in reverse. If that 2px border on the left and right edges doesn't sit well with folks, we can change the border for that container (.card h1) to only have a top and bottom border, which would eliminate those on the side. I think it looks good, though...for now. ;) I also made sure that it has consistent spacing around the letters by removing the grid-template-rows setting. I considered putting more spacing around the letters (top and bottom) but realized this header is there for symbolic reasons, so I did not want to call too much attention to it and take up too much room for those playing with mobile devices or small screens. No one is calling out the spaces: "N Cute dog. N...Cute dog." Or...are they? :O

<img width="619" alt="Screen Shot 2019-11-19 at 04 10 12" src="https://user-images.githubusercontent.com/10199991/69132660-81ec6180-0a82-11ea-8926-651024802f6d.png">

