### PR TITLE
Add soft hyphen

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ gcloud config set project bingo-card-257920
 
 * Deploy the site with : `npm run deploy`
 
+## Prompts
+
+You can create your own prompts in a JSON file. The default is [film-tropes](www/film-tropes.json).
+This is designed for use while viewing shmaltzy Christmas movies.
+You can specify another file in a URL parameter `cluefile=` (name to change).
+
+In the prompt file, Long words can be marked for hyphenation using [soft hyphens](https://en.wikipedia.org/wiki/Soft_hyphen)
+`\U00AD`. This will cause the word to break when needed on small screens.
+
 ## Credits
 
 Thanks to people who have contributed to the [film-tropes](www/film-tropes.json): Mary Stockert, Rebecca Putman, Walter Francis

--- a/www/film-tropes.json
+++ b/www/film-tropes.json
@@ -61,7 +61,7 @@
   "Holiday-themed first name",
   "Christmas tree farm",
   "Overheard conversation",
-  "Misunderstanding",
+  "Mis\u00adunderstanding",
   "Falling in love",
   "Snowman",
   "Wearing pajamas",


### PR DESCRIPTION
The long word "misunderstanding" pushes the cells too wide on mobile. Adding a soft hyphen will only hyphenate if it is needed. 