### PR TITLE
CI/CD with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           root: ~/repo
           # Must be relative path from root
           paths:
-            - www/*
+            - www/index.html
 
   deploy:
     executor: node-gcp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,21 +44,21 @@ jobs:
           paths:
             - www
 
-    deploy:
-      docker:
-        - image: google/cloud-sdk
+  deploy:
+    docker:
+      - image: google/cloud-sdk
 
-      working_directory: ~/repo
+    working_directory: ~/repo
 
-      steps:
-          - attach_workspace:
-          # Must be absolute path or relative path from working_directory
-              at: ~/repo
-          - run: |
-              echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
-              gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
-              gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
-              gsutil rsync -m -r www gs://www.bingocard.me
+    steps:
+        - attach_workspace:
+        # Must be absolute path or relative path from working_directory
+            at: ~/repo
+        - run: |
+            echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
+            gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
+            gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
+            gsutil rsync -m -r www gs://www.bingocard.me
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,14 +36,32 @@ jobs:
       # run tests!
       - run: npm run build
 
-      - store_artifacts:
-          path: ~/repo/www
+      - persist_to_workspace:
+          # Must be an absolute path, or relative path from working_directory. This is a directory on the container which is
+          # taken to be the root directory of the workspace.
+          root: ~/repo
+          # Must be relative path from root
+          paths:
+            - www
 
     deploy:
       docker:
         - image: google/cloud-sdk
+
+      working_directory: ~/repo
+
       steps:
+          - attach_workspace:
+          # Must be absolute path or relative path from working_directory
+              at: ~/repo
           - run: |
               echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
               gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
               gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
+              gsutil rsync -m -r www gs://www.bingocard.me
+
+workflows:
+  build_and_deploy:
+    jobs:
+      - build
+      - deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2.1
 executors:
   node-gcp:
     docker:
-      - image: haroldputman/circleci-node-gcp:0.0.1
+      - image: haroldputman/circleci-node-gcp:0.0.2
     working_directory: ~/repo
 
 jobs:
@@ -31,7 +31,7 @@ jobs:
           root: ~/repo
           # Must be relative path from root
           paths:
-            - www
+            - www/*
 
   deploy:
     executor: node-gcp
@@ -39,7 +39,7 @@ jobs:
         - attach_workspace:
             at: ~/repo/www
         - run: pwd
-        - run: ls -al
+        - run: ls -aRl
         - run: |
             echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --project ${GOOGLE_PROJECT_ID} --key-file=-
             gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 #
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
@@ -61,6 +61,7 @@ jobs:
               gsutil rsync -m -r www gs://www.bingocard.me
 
 workflows:
+  version: 2
   build_and_deploy:
     jobs:
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,3 +35,6 @@ jobs:
 
       # run tests!
       - run: npm run build
+
+      - store_artifacts:
+          path: ~/repo/www

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,19 +26,21 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
       - run: npm run build
+      - run: mkdir -p workspace
+      - run: echo "Hello, world!" > workspace/echo-output
       - persist_to_workspace:
           # Must be an absolute path, or relative path from working_directory. This is a directory on the container which is
           # taken to be the root directory of the workspace.
-          root: ~/repo
+          root: workspace
           # Must be relative path from root
           paths:
-            - www/index.html
+            - echo-output
 
   deploy:
     executor: node-gcp
     steps:
         - attach_workspace:
-            at: ~/repo/www
+            at: ~/repo/workspace
         - run: pwd
         - run: ls -aRl
         - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
             ls ~/repo
             echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --project ${GOOGLE_PROJECT_ID} --key-file=-
             gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
-            gsutil rsync -r ~/repo/www gs://www.bingocard.me
+            gsutil rsync -r ~/repo gs://www.bingocard.me
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,10 +55,11 @@ jobs:
         # Must be absolute path or relative path from working_directory
             at: ~/repo
         - run: |
-            ls
+            pwd
+            ls ~/repo
             echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --project ${GOOGLE_PROJECT_ID} --key-file=-
             gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
-            gsutil rsync -r ~/repo www gs://www.bingocard.me
+            gsutil rsync -r ~/repo/www gs://www.bingocard.me
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,14 +34,16 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
 
       - run: npm run build
+      - run: mkdir -p workspace
+      - run: echo "Hello, world!" > workspace/echo-output
 
       - persist_to_workspace:
           # Must be an absolute path, or relative path from working_directory. This is a directory on the container which is
           # taken to be the root directory of the workspace.
-          root: .
+          root: workspace
           # Must be relative path from root
           paths:
-            - www/*
+            - echo-output
 
   deploy:
     docker:
@@ -59,6 +61,13 @@ jobs:
             echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --project ${GOOGLE_PROJECT_ID} --key-file=-
             gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
             gsutil rsync -r ~/repo/workspace gs://www.bingocard.me
+
+        - run: |
+          if [[ `cat /tmp/workspace/echo-output` == "Hello, world!" ]]; then
+            echo "It worked!";
+          else
+            echo "Nope!"; exit 1
+          fi
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,11 +63,9 @@ jobs:
             gsutil rsync -r ~/repo/workspace gs://www.bingocard.me
 
         - run: |
-          if [[ `cat /tmp/workspace/echo-output` == "Hello, world!" ]]; then
-            echo "It worked!";
-          else
-            echo "Nope!"; exit 1
-          fi
+            if [[ `cat /tmp/workspace/echo-output` == "Hello, world!" ]]; then
+              echo "It worked!";
+            fi
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,3 +38,12 @@ jobs:
 
       - store_artifacts:
           path: ~/repo/www
+
+    deploy:
+      docker:
+        - image: google/cloud-sdk
+      steps:
+          - run: |
+              echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
+              gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
+              gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+# Javascript Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:10.14
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/mongo:3.4.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: npm install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      # run tests!
+      - run: npm run build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,21 +26,19 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
       - run: npm run build
-      - run: mkdir -p workspace
-      - run: echo "Hello, world!" > workspace/echo-output
       - persist_to_workspace:
           # Must be an absolute path, or relative path from working_directory. This is a directory on the container which is
           # taken to be the root directory of the workspace.
-          root: workspace
+          root: ~/repo
           # Must be relative path from root
           paths:
-            - echo-output
+            - www/*
 
   deploy:
     executor: node-gcp
     steps:
         - attach_workspace:
-            at: ~/repo/workspace
+            at: ~/repo
         - run: pwd
         - run: ls -aRl
         - run: |
@@ -53,4 +51,6 @@ workflows:
   build_and_deploy:
     jobs:
       - build
-      - deploy
+      - deploy:
+          requires:
+              - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,10 +55,9 @@ jobs:
         # Must be absolute path or relative path from working_directory
             at: ~/repo
         - run: |
-            echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
-            gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
+            echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --project ${GOOGLE_PROJECT_ID} --key-file=-
             gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
-            gsutil rsync -m -r www gs://www.bingocard.me
+            gsutil rsync -r www gs://www.bingocard.me
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,69 +3,47 @@
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
 version: 2.1
-jobs:
-  build:
+
+executors:
+  node-gcp:
     docker:
-      # specify the version you desire here
-      - image: circleci/node:10.14
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/mongo:3.4.4
-
+      - image: haroldputman/circleci-node-gcp:0.0.1
     working_directory: ~/repo
 
+jobs:
+  build:
+    executor: node-gcp
     steps:
       - checkout
-
-      # Download and cache dependencies
       - restore_cache:
           keys:
             - v1-dependencies-{{ checksum "package.json" }}
-            # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
-
       - run: npm install
-
       - save_cache:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
-
       - run: npm run build
-      - run: mkdir -p workspace
-      - run: echo "Hello, world!" > workspace/echo-output
-
       - persist_to_workspace:
           # Must be an absolute path, or relative path from working_directory. This is a directory on the container which is
           # taken to be the root directory of the workspace.
-          root: workspace
+          root: ~/repo
           # Must be relative path from root
           paths:
-            - echo-output
+            - www
 
   deploy:
-    docker:
-      - image: google/cloud-sdk
-
-    working_directory: ~/repo
-
+    executor: node-gcp
     steps:
         - attach_workspace:
-        # Must be absolute path or relative path from working_directory
-            at: ~/repo/workspace
+            at: ~/repo/www
         - run: pwd
         - run: ls -al
         - run: |
             echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --project ${GOOGLE_PROJECT_ID} --key-file=-
             gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
-            gsutil rsync -r ~/repo/workspace gs://www.bingocard.me
-
-        - run: |
-            if [[ `cat ~/repo/workspace/echo-output` == "Hello, world!" ]]; then
-              echo "It worked!";
-            fi
+            gsutil rsync -r ~/repo/www gs://www.bingocard.me
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,15 +55,15 @@ jobs:
         - attach_workspace:
         # Must be absolute path or relative path from working_directory
             at: ~/repo/workspace
+        - run: pwd
+        - run: ls -al
         - run: |
-            pwd
-            ls ~/repo/workspace
             echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --project ${GOOGLE_PROJECT_ID} --key-file=-
             gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
             gsutil rsync -r ~/repo/workspace gs://www.bingocard.me
 
         - run: |
-            if [[ `cat /tmp/workspace/echo-output` == "Hello, world!" ]]; then
+            if [[ `cat ~/repo/workspace/echo-output` == "Hello, world!" ]]; then
               echo "It worked!";
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,9 +55,10 @@ jobs:
         # Must be absolute path or relative path from working_directory
             at: ~/repo
         - run: |
+            ls
             echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --project ${GOOGLE_PROJECT_ID} --key-file=-
             gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
-            gsutil rsync -r www gs://www.bingocard.me
+            gsutil rsync -r ~/repo www gs://www.bingocard.me
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
             - v1-dependencies-{{ checksum "package.json" }}
             - v1-dependencies-
       - run: npm install
+      - run: ls -al . www
       - save_cache:
           paths:
             - node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,16 +33,15 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
 
-      # run tests!
       - run: npm run build
 
       - persist_to_workspace:
           # Must be an absolute path, or relative path from working_directory. This is a directory on the container which is
           # taken to be the root directory of the workspace.
-          root: ~/repo
+          root: .
           # Must be relative path from root
           paths:
-            - www
+            - www/*
 
   deploy:
     docker:
@@ -53,13 +52,13 @@ jobs:
     steps:
         - attach_workspace:
         # Must be absolute path or relative path from working_directory
-            at: ~/repo
+            at: ~/repo/workspace
         - run: |
             pwd
-            ls ~/repo
+            ls ~/repo/workspace
             echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --project ${GOOGLE_PROJECT_ID} --key-file=-
             gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
-            gsutil rsync -r ~/repo gs://www.bingocard.me
+            gsutil rsync -r ~/repo/workspace gs://www.bingocard.me
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,3 +54,6 @@ workflows:
       - deploy:
           requires:
               - build
+          filters:
+            branches:
+              only: master

--- a/.circleci/images/circleci-node-gcp/Dockerfile
+++ b/.circleci/images/circleci-node-gcp/Dockerfile
@@ -1,0 +1,18 @@
+FROM circleci/node:10.14.2-browsers
+
+USER root
+
+ENV CCI /home/circleci
+ENV GTMP /tmp/gcloud-install
+ENV GSDK $CCI/google-cloud-sdk
+ENV PATH="${GSDK}/bin:${PATH}"
+
+# do all system lib installation in one-line to optimize layers
+RUN curl -sSL https://sdk.cloud.google.com > $GTMP && bash $GTMP --install-dir=$CCI --disable-prompts \
+  && rm -rf $GTMP \
+  && chmod +x $GSDK/bin/* \
+  \
+  && chown -Rf circleci:circleci $CCI
+
+# change back to the user in the FROM image
+USER circleci

--- a/.circleci/images/circleci-node-gcp/Dockerfile
+++ b/.circleci/images/circleci-node-gcp/Dockerfile
@@ -14,5 +14,10 @@ RUN curl -sSL https://sdk.cloud.google.com > $GTMP && bash $GTMP --install-dir=$
   \
   && chown -Rf circleci:circleci $CCI
 
+# install crcmod (gsutil help crcmod)
+RUN sudo apt-get install gcc python-dev python-setuptools
+RUN sudo easy_install pip
+RUN sudo sh -c 'pip uninstall crcmod && pip install --no-cache-dir -U crcmod'
+
 # change back to the user in the FROM image
 USER circleci

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It is easily extended to other domains by adding new prompts.
 
 ## Quickstart
 
-### To test this locally:
+### Test locally
 
 * Clone the repo and install it.
 
@@ -17,20 +17,21 @@ npm install
 * Start the local server with `npm start`.
 * Visit [localhost:3000](http://localhost:3000).
 
-### Deploy to web
+### Setting up CircleCI
 
-When you are ready to deploy to Google Cloud Storage:
+I am using [CircleCI](https://circleci.com/) to deploy to the web. When changes are
+merged into master they will be automatically deployed.
 
-* Set up and connect to your GCP account and project
+The [current configuration](.circleci/config.yml) is set up to deploy to Google Cloud
+Storage. There are some environment variables that must be set in your Circle CI
+environment:
 
-```sh
-gcloud auth login
-gcloud config set project bingo-card-257920
-```
-
-* Deploy the site with : `npm run deploy`
+* `GCLOUD_SERVICE_KEY` Create a service user in GCP Console and set the key here. It's JSON data.
+* `GOOGLE_COMPUTE_ZONE` The Google Compute zone (us-east1)
+* `GOOGLE_PROJECT_ID` The Project ID.
 
 ## Credits
 
-Thanks to people who have contributed to the [film-tropes](www/film-tropes.json): Mary Stockert, Rebecca Putman, Walter Francis
-
+Thanks to people who have contributed to the [film-tropes](www/film-tropes.json):
+Mary Stockert, Rebecca Putman, Walter Francis. Thanks also to Cary Hazelwood who
+helped with Sass/CSS and other good ideas.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server",
-    "build": "mkdir www/foo & echo test > www/foo/test.txt",
+    "build": "pwd > www/test.txt",
     "deploy": "gsutil rsync -r www gs://www.bingocard.me",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server",
-    "build": "echo test > www/test.txt",
+    "build": "mkdir www/foo & echo test > www/foo/test.txt",
     "deploy": "gsutil rsync -r www gs://www.bingocard.me",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "start": "node server",
     "build": "pwd > www/test.txt",
-    "deploy": "gsutil rsync -r www gs://www.bingocard.me",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server",
+    "build": "echo test > www/test.txt",
     "deploy": "gsutil rsync -r www gs://www.bingocard.me",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Implements #9 

So, it doesn't do much yet, but the plumbing is in place to get CircleCI to build and deploy every merge to master. This was harder than I think it should have been. I wasted alot of time trying to understand `persist-to-workspace`. The hidden secret is that in the workflow you have to have the downstream job 'depend' on the upstream job. 'deploy' depends on 'build'. Seems obvious now.